### PR TITLE
Improve mobile responsiveness across all breakpoints

### DIFF
--- a/src/AppFooter.css
+++ b/src/AppFooter.css
@@ -34,3 +34,23 @@
 .App-footer-heart {
   color: var(--tile-color);
 }
+
+@media (max-width: 768px) {
+  .App-footer {
+    padding: 20px 16px;
+    font-size: 0.8em;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .App-footer {
+    padding: 16px 12px;
+    font-size: 0.75em;
+    gap: 6px;
+  }
+
+  .App-footer p {
+    line-height: 1.4;
+  }
+}

--- a/src/AppHeader.css
+++ b/src/AppHeader.css
@@ -50,3 +50,47 @@
 .App-header-icon {
   font-size: 1.1em;
 }
+
+@media (max-width: 768px) {
+  .App-header {
+    padding: 10px 16px;
+  }
+
+  .App-header h2 {
+    font-size: 0.85em;
+  }
+
+  .App-header-controls {
+    gap: 16px;
+  }
+
+  .App-header-btn,
+  .App-header-stat {
+    font-size: 0.75em;
+    gap: 4px;
+  }
+
+  .App-header-icon {
+    font-size: 1em;
+  }
+}
+
+@media (max-width: 480px) {
+  .App-header {
+    padding: 8px 12px;
+  }
+
+  .App-header h2 {
+    font-size: 0.8em;
+  }
+
+  .App-header-controls {
+    gap: 12px;
+  }
+
+  .App-header-btn,
+  .App-header-stat {
+    font-size: 0.7em;
+    gap: 3px;
+  }
+}

--- a/src/AttemptsLeft.css
+++ b/src/AttemptsLeft.css
@@ -7,3 +7,9 @@
   font-weight: 600;
   color: var(--tile-color);
 }
+
+@media (max-width: 480px) {
+  .AttemptsLeft {
+    font-size: 0.85em;
+  }
+}

--- a/src/Game.css
+++ b/src/Game.css
@@ -69,3 +69,62 @@
   font-weight: 600;
   letter-spacing: 1px;
 }
+
+@media (max-width: 768px) {
+  .Game-content {
+    padding: 24px 16px;
+  }
+
+  .Game-SideBySide {
+    gap: 32px;
+  }
+
+  .Game-InputPanel {
+    gap: 20px;
+  }
+
+  .Game-Hangman {
+    min-width: 200px;
+    min-height: 250px;
+  }
+
+  .Game-Hangman svg {
+    width: 200px;
+    height: 220px;
+  }
+}
+
+@media (max-width: 480px) {
+  .Game-content {
+    padding: 16px 12px;
+  }
+
+  .Game-SideBySide {
+    gap: 24px;
+    flex-direction: column-reverse;
+  }
+
+  .Game-InputPanel {
+    gap: 16px;
+    width: 100%;
+  }
+
+  .Game-Hangman {
+    min-width: 160px;
+    min-height: 200px;
+  }
+
+  .Game-Hangman svg {
+    width: 160px;
+    height: 176px;
+  }
+
+  .Game-InputPanel .Game-GameWin,
+  .Game-InputPanel .Game-GameOver {
+    font-size: 0.9em;
+  }
+
+  .Game-CheatIndicator {
+    font-size: 0.65em;
+  }
+}

--- a/src/LetterBlock.css
+++ b/src/LetterBlock.css
@@ -22,3 +22,36 @@
   font-weight: 400;
   font-size: 0.9em;
 }
+
+@media (max-width: 768px) {
+  .LetterBlock {
+    width: 36px;
+    height: 36px;
+  }
+
+  .LetterBlock > span {
+    font-size: 0.85em;
+  }
+}
+
+@media (max-width: 480px) {
+  .LetterBlock {
+    width: 32px;
+    height: 32px;
+  }
+
+  .LetterBlock > span {
+    font-size: 0.8em;
+  }
+}
+
+@media (max-width: 360px) {
+  .LetterBlock {
+    width: 28px;
+    height: 28px;
+  }
+
+  .LetterBlock > span {
+    font-size: 0.75em;
+  }
+}

--- a/src/LettersRow.css
+++ b/src/LettersRow.css
@@ -3,3 +3,15 @@
   gap: 4px;
   justify-content: center;
 }
+
+@media (max-width: 480px) {
+  .LettersRow {
+    gap: 3px;
+  }
+}
+
+@media (max-width: 360px) {
+  .LettersRow {
+    gap: 2px;
+  }
+}

--- a/src/RestartButton.css
+++ b/src/RestartButton.css
@@ -24,3 +24,14 @@
 .App-Restart > button:active {
   transform: scale(0.98);
 }
+
+@media (max-width: 480px) {
+  .App-Restart {
+    margin-top: 12px;
+  }
+
+  .App-Restart > button {
+    padding: 8px 16px;
+    font-size: 0.8em;
+  }
+}

--- a/src/Word.css
+++ b/src/Word.css
@@ -17,3 +17,35 @@
   background: var(--tile-color);
   color: var(--text-light);
 }
+
+@media (max-width: 768px) {
+  .Word > span {
+    width: 44px;
+    height: 44px;
+    font-size: 1.3em;
+  }
+}
+
+@media (max-width: 480px) {
+  .Word {
+    gap: 3px;
+  }
+
+  .Word > span {
+    width: 36px;
+    height: 36px;
+    font-size: 1.1em;
+  }
+}
+
+@media (max-width: 360px) {
+  .Word {
+    gap: 2px;
+  }
+
+  .Word > span {
+    width: 30px;
+    height: 30px;
+    font-size: 0.95em;
+  }
+}


### PR DESCRIPTION
- Add responsive styles for tablets (768px), phones (480px), and small phones (360px)
- Reduce header padding and font sizes on mobile devices
- Optimize game layout with smaller gaps and reverse column layout on mobile
- Scale down hangman SVG from 250px to 160px on small screens
- Reduce word tile sizes from 52px to 30-36px based on screen size
- Optimize virtual keyboard letter blocks for touch (28-38px)
- Improve footer spacing and font sizes for mobile
- Adjust restart button and attempts display for smaller screens
- Maintain touch-friendly tap targets while maximizing screen real estate